### PR TITLE
v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
   "scripts": {
     "start": "ts-node demo.ts",
     "build": "yarn tsc",
-    "publish": "yarn publish ./",
+    "publish:release": "yarn build && yarn publish",
     "lint": "yarn lint:ts && yarn lint:js",
     "lint:js": "eslint --cache --ext '.ts,.tsx,.js,.jsx' .",
     "lint:ts": "yarn tsc --skipLibCheck --noEmit"
   },
-  "prepublish": "yarn build",
   "dependencies": {
     "@ethersproject/providers": "^5.5.0",
     "bignumber.js": "^9.0.1",


### PR DESCRIPTION
having `publish` as script was overriding the default `yarn publish` so it was being called twice without running `yarn build` before publishing