### PR TITLE
Handle outliers priority fee data values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eip1559-fee-suggestions-ethers",
+  "name": "@rainbow-me/fee-suggestions",
   "description": "JavaScript library that suggest fees on Ethereum after EIP-1559 using historical data using ethers.js",
   "version": "1.3.3",
   "main": "dist/index.js",

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -20,7 +20,6 @@ export interface MaxPriorityFeeSuggestions {
     30: string;
     45: string;
     60: string;
-    75: string;
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,80 +4,15 @@ import {
   FeeHistoryResponse,
   MaxFeeSuggestions,
   MaxPriorityFeeSuggestions,
-  Reward,
   Suggestions,
 } from './entities';
-import { gweiToWei, weiToGweiNumber } from './utils';
-
-// samplingCurve is a helper function for the base fee percentile range calculation.
-const samplingCurve = (
-  sumWeight: number,
-  sampleMin: number,
-  sampleMax: number
-) => {
-  if (sumWeight <= sampleMin) {
-    return 0;
-  }
-  if (sumWeight >= sampleMax) {
-    return 1;
-  }
-  return (
-    (1 -
-      Math.cos(
-        ((sumWeight - sampleMin) * 2 * Math.PI) / (sampleMax - sampleMin)
-      )) /
-    2
-  );
-};
-
-const linearRegression = (y: number[], x: number[]) => {
-  const n = y.length;
-  let sumX = 0;
-  let sumY = 0;
-  let sumXY = 0;
-  let sumXX = 0;
-
-  for (let i = 0; i < y.length; i++) {
-    const cY = Number(y[i]);
-    const cX = Number(x[i]);
-    sumX += cX;
-    sumY += cY;
-    sumXY += cX * cY;
-    sumXX += cX * cX;
-  }
-  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-
-  return slope;
-};
-
-const suggestBaseFee = (
-  baseFee: number[],
-  order: number[],
-  timeFactor: number,
-  sampleMin: number,
-  sampleMax: number
-) => {
-  if (timeFactor < 1e-6) {
-    return baseFee[baseFee.length - 1];
-  }
-  const pendingWeight =
-    (1 - Math.exp(-1 / timeFactor)) /
-    (1 - Math.exp(-baseFee.length / timeFactor));
-  let sumWeight = 0;
-  let result = 0;
-  let samplingCurveLast = 0;
-  for (let or of order) {
-    sumWeight +=
-      pendingWeight * Math.exp((or - baseFee.length + 1) / timeFactor);
-    const samplingCurveValue = samplingCurve(sumWeight, sampleMin, sampleMax);
-    result += (samplingCurveValue - samplingCurveLast) * baseFee[or];
-    if (samplingCurveValue >= 1) {
-      return result;
-    }
-    samplingCurveLast = samplingCurveValue;
-  }
-  return result;
-};
+import {
+  gweiToWei,
+  linearRegression,
+  rewardsFilterOutliers,
+  suggestBaseFee,
+  weiToGweiNumber,
+} from './utils';
 
 export const suggestMaxBaseFee = async (
   provider: JsonRpcProvider,
@@ -143,11 +78,6 @@ export const suggestMaxBaseFee = async (
     baseFeeTrend: trend,
   };
 };
-
-const rewardsFilterOutliers = (blocksRewards: Reward[], index: number) =>
-  blocksRewards
-    .map((reward) => weiToGweiNumber(reward[index]))
-    .filter((gweiReward) => gweiReward <= 10);
 
 export const suggestMaxPriorityFee = async (
   provider: JsonRpcProvider,

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export const suggestMaxPriorityFee = async (
     maxPriorityFeeSuggestions: {
       fast: gweiToWei(Math.max(emaPerc30, 1.5)),
       normal: gweiToWei(Math.max(emaPerc15, 1)),
-      urgent: gweiToWei(emaPerc45),
+      urgent: gweiToWei(Math.max(emaPerc45, 2)),
     },
   };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { Reward } from './entities';
 
 type BigNumberish = number | string | BigNumber;
 
@@ -33,3 +34,77 @@ export const weiToGweiNumber = (weiAmount: BigNumberish) => {
   const gweiAmount = divide(weiAmount, ethUnits.gwei).toNumber();
   return gweiAmount;
 };
+
+export const samplingCurve = (
+  sumWeight: number,
+  sampleMin: number,
+  sampleMax: number
+) => {
+  if (sumWeight <= sampleMin) {
+    return 0;
+  }
+  if (sumWeight >= sampleMax) {
+    return 1;
+  }
+  return (
+    (1 -
+      Math.cos(
+        ((sumWeight - sampleMin) * 2 * Math.PI) / (sampleMax - sampleMin)
+      )) /
+    2
+  );
+};
+
+export const linearRegression = (y: number[], x: number[]) => {
+  const n = y.length;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+
+  for (let i = 0; i < y.length; i++) {
+    const cY = Number(y[i]);
+    const cX = Number(x[i]);
+    sumX += cX;
+    sumY += cY;
+    sumXY += cX * cY;
+    sumXX += cX * cX;
+  }
+  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+
+  return slope;
+};
+
+export const suggestBaseFee = (
+  baseFee: number[],
+  order: number[],
+  timeFactor: number,
+  sampleMin: number,
+  sampleMax: number
+) => {
+  if (timeFactor < 1e-6) {
+    return baseFee[baseFee.length - 1];
+  }
+  const pendingWeight =
+    (1 - Math.exp(-1 / timeFactor)) /
+    (1 - Math.exp(-baseFee.length / timeFactor));
+  let sumWeight = 0;
+  let result = 0;
+  let samplingCurveLast = 0;
+  for (let or of order) {
+    sumWeight +=
+      pendingWeight * Math.exp((or - baseFee.length + 1) / timeFactor);
+    const samplingCurveValue = samplingCurve(sumWeight, sampleMin, sampleMax);
+    result += (samplingCurveValue - samplingCurveLast) * baseFee[or];
+    if (samplingCurveValue >= 1) {
+      return result;
+    }
+    samplingCurveLast = samplingCurveValue;
+  }
+  return result;
+};
+
+export const rewardsFilterOutliers = (blocksRewards: Reward[], index: number) =>
+  blocksRewards
+    .map((reward) => weiToGweiNumber(reward[index]))
+    .filter((gweiReward) => gweiReward <= 10);


### PR DESCRIPTION
Remove data priority fees data outliers (>10) to improve the overpaid ratio between the estimated priority fee and the block min priority fee. Also moved some methods to utils