### PR TITLE
Update on gas fee trend calculations

### DIFF
--- a/src/entities.ts
+++ b/src/entities.ts
@@ -19,14 +19,14 @@ export interface FeeHistoryResponse {
 /**
  * Max base fee related suggestions
  *
- * @member maxBaseFeeSuggestion - Base fee suggestion in wei string
  * @member baseFeeTrend - Estimated trend
  * @member currentBaseFee - Current block base fee in wei string
+ * @member maxBaseFeeSuggestion - Base fee suggestion in wei string
  */
 export interface MaxFeeSuggestions {
-  maxBaseFeeSuggestion: string;
-  currentBaseFee: string;
   baseFeeTrend: number;
+  currentBaseFee: string;
+  maxBaseFeeSuggestion: string;
 }
 
 /**
@@ -36,13 +36,13 @@ export interface MaxFeeSuggestions {
  * @member confirmationTimeByPriorityFee - Object containing estimated seconds that a confirmation is going to happen if `confirmationTimeByPriorityFee[secs]` is used as `maxPriorityfee`, in wei string
  */
 export interface MaxPriorityFeeSuggestions {
-  maxPriorityFeeSuggestions: { urgent: string; fast: string; normal: string };
   confirmationTimeByPriorityFee: {
     15: string;
     30: string;
     45: string;
     60: string;
   };
+  maxPriorityFeeSuggestions: { urgent: string; fast: string; normal: string };
 }
 
 export interface Suggestions

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -27,6 +27,7 @@ export interface MaxFeeSuggestions {
   maxBaseFeeSuggestion: string;
   currentBaseFee: string;
   baseFeeTrend: number;
+  trends: {};
 }
 
 /**

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -19,14 +19,14 @@ export interface FeeHistoryResponse {
 /**
  * Max base fee related suggestions
  *
+ * @member baseFeeSuggestion - Base fee suggestion in wei string
  * @member baseFeeTrend - Estimated trend
  * @member currentBaseFee - Current block base fee in wei string
- * @member maxBaseFeeSuggestion - Base fee suggestion in wei string
  */
 export interface MaxFeeSuggestions {
+  baseFeeSuggestion: string;
   baseFeeTrend: number;
   currentBaseFee: string;
-  maxBaseFeeSuggestion: string;
 }
 
 /**

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -27,7 +27,6 @@ export interface MaxFeeSuggestions {
   maxBaseFeeSuggestion: string;
   currentBaseFee: string;
   baseFeeTrend: number;
-  trends: {};
 }
 
 /**

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -25,8 +25,8 @@ export interface FeeHistoryResponse {
  */
 export interface MaxFeeSuggestions {
   maxBaseFeeSuggestion: string;
-  baseFeeTrend: number;
   currentBaseFee: string;
+  baseFeeTrend: number;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,15 @@ import {
   Suggestions,
 } from './entities';
 import {
+  calculateBaseFeeTrend,
   getOutlierBlocksToRemove,
   gweiToWei,
-  linearRegression,
   rewardsFilterOutliers,
   suggestBaseFee,
   weiToGweiNumber,
   weiToString,
 } from './utils';
+
 export const suggestMaxBaseFee = async (
   provider: JsonRpcProvider,
   fromBlock = 'latest',
@@ -34,96 +35,8 @@ export const suggestMaxBaseFee = async (
     baseFees.push(weiToGweiNumber(feeHistory.baseFeePerGas[i]));
     order.push(i);
   }
-  // calculate max, min and median
-  const calc = (baseFees: number[]) => {
-    const sortedBaseFees = baseFees.sort((a, b) => a - b);
-    const min = sortedBaseFees[0];
-    const max = sortedBaseFees[sortedBaseFees.length - 1];
-    const median = sortedBaseFees[Math.floor(sortedBaseFees.length / 2)];
-    return { max, median, min };
-  };
-  const createSubsets = (numbers: number[], n: number) => {
-    const subsets = [];
-    for (let i = 0; i < numbers.length; i = i + n) {
-      subsets.push(numbers.slice(i, i + n));
-    }
-    return subsets;
-  };
-  const getSubsetsData = (numbers: number[], n: number) => {
-    const subsets = createSubsets(numbers, n);
-    const subsetsInfo = subsets.map((subset) => calc(subset));
-    return subsetsInfo;
-  };
-  const getData = (numbers: number[], n: number) => {
-    const subsetsData = getSubsetsData(numbers, n);
-    const maxData = subsetsData.map((data) => data.max);
-    const minData = subsetsData.map((data) => data.min);
-    const medianData = subsetsData.map((data) => data.median);
-    const maxLR = linearRegression(maxData);
-    const minLR = linearRegression(minData);
-    const medianLR = linearRegression(medianData);
-    return {
-      max: maxData[maxData.length - 1],
-      maxLR,
-      median: medianData[medianData.length - 1],
-      medianLR,
-      min: minData[minData.length - 1],
-      minLR,
-    };
-  };
-  const baseFees5Blocks = baseFees.slice(blockCountHistory - 5 + 1);
-  const n5 = {
-    g1: getData(baseFees5Blocks, 1),
-    g5: getData(baseFees5Blocks, 5),
-  };
-  const baseFees25Blocks = baseFees.slice(blockCountHistory - 25 + 1);
-  const n25 = {
-    g1: getData(baseFees25Blocks, 1),
-    g5: getData(baseFees25Blocks, 5),
-  };
-  // blocks 50
-  const baseFees50Blocks = baseFees.slice(blockCountHistory - 50 + 1);
-  // groups 1, 5, 10
-  const n50 = {
-    g1: getData(baseFees50Blocks, 1),
-    g10: getData(baseFees50Blocks, 10),
-    g5: getData(baseFees50Blocks, 5),
-  };
-  // blocks 100
-  const baseFees100Blocks = baseFees.slice(1);
-  // groups 1, 5, 10
-  const n100 = {
-    g1: getData(baseFees100Blocks, 1),
-    g10: getData(baseFees100Blocks, 10),
-    g25: getData(baseFees100Blocks, 25),
-    g5: getData(baseFees100Blocks, 5),
-    g50: getData(baseFees100Blocks, 50),
-  };
-  // /////////////
-  const maxByMedian = n100.g25.max / n100.g25.median;
-  const minByMedian = n100.g25.min / n100.g25.median;
-  let trend = 0;
-  // surging
-  if (maxByMedian > 1.5) {
-    trend = 2;
-  } else if (maxByMedian > 1.275 && minByMedian > 0.725) {
-    trend = 1;
-  } else if (maxByMedian < 1.275 && minByMedian > 0.725) {
-    if (n50.g5.medianLR < -5) {
-      trend = -1;
-    } else {
-      trend = 0;
-    }
-  } else if (maxByMedian < 1.275 && minByMedian < 0.725) {
-    trend = -1;
-  } else {
-    // if none is on the threshold
-    if (weiToGweiNumber(currentBaseFee) > n100.g25.median) {
-      trend = 1;
-    } else {
-      trend = -1;
-    }
-  }
+  const baseFeeTrend = calculateBaseFeeTrend(baseFees, currentBaseFee);
+
   baseFees[baseFees.length - 1] *= 9 / 8;
   for (let i = feeHistory.gasUsedRatio.length - 1; i >= 0; i--) {
     if (feeHistory.gasUsedRatio[i] > 0.9) {
@@ -154,15 +67,9 @@ export const suggestMaxBaseFee = async (
   }
   const suggestedMaxBaseFee = Math.max(...result);
   return {
-    baseFeeTrend: trend,
+    baseFeeTrend,
     currentBaseFee,
     maxBaseFeeSuggestion: gweiToWei(suggestedMaxBaseFee),
-    trends: {
-      n100,
-      n25,
-      n5,
-      n50,
-    },
   };
 };
 export const suggestMaxPriorityFee = async (
@@ -231,7 +138,7 @@ export const suggestMaxPriorityFee = async (
 export const suggestFees = async (
   provider: JsonRpcProvider
 ): Promise<Suggestions> => {
-  const { maxBaseFeeSuggestion, trends, baseFeeTrend, currentBaseFee } =
+  const { maxBaseFeeSuggestion, baseFeeTrend, currentBaseFee } =
     await suggestMaxBaseFee(provider);
   const { maxPriorityFeeSuggestions, confirmationTimeByPriorityFee } =
     await suggestMaxPriorityFee(provider);
@@ -241,6 +148,5 @@ export const suggestFees = async (
     currentBaseFee,
     maxBaseFeeSuggestion,
     maxPriorityFeeSuggestions,
-    trends,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,9 @@ export const suggestMaxBaseFee = async (
   }
   const suggestedMaxBaseFee = Math.max(...result);
   return {
+    baseFeeSuggestion: gweiToWei(suggestedMaxBaseFee),
     baseFeeTrend,
     currentBaseFee,
-    maxBaseFeeSuggestion: gweiToWei(suggestedMaxBaseFee),
   };
 };
 export const suggestMaxPriorityFee = async (
@@ -138,15 +138,15 @@ export const suggestMaxPriorityFee = async (
 export const suggestFees = async (
   provider: JsonRpcProvider
 ): Promise<Suggestions> => {
-  const { maxBaseFeeSuggestion, baseFeeTrend, currentBaseFee } =
+  const { baseFeeSuggestion, baseFeeTrend, currentBaseFee } =
     await suggestMaxBaseFee(provider);
   const { maxPriorityFeeSuggestions, confirmationTimeByPriorityFee } =
     await suggestMaxPriorityFee(provider);
   return {
+    baseFeeSuggestion,
     baseFeeTrend,
     confirmationTimeByPriorityFee,
     currentBaseFee,
-    maxBaseFeeSuggestion,
     maxPriorityFeeSuggestions,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,42 +7,129 @@ import {
   Suggestions,
 } from './entities';
 import {
-  calculateBaseFeeTrend,
   getOutlierBlocksToRemove,
   gweiToWei,
+  linearRegression,
   rewardsFilterOutliers,
   suggestBaseFee,
   weiToGweiNumber,
   weiToString,
 } from './utils';
-
 export const suggestMaxBaseFee = async (
   provider: JsonRpcProvider,
-  fromBlock = 'latest'
+  fromBlock = 'latest',
+  blockCountHistory = 100
 ): Promise<MaxFeeSuggestions> => {
   const feeHistory: FeeHistoryResponse = await provider.send('eth_feeHistory', [
-    100,
+    blockCountHistory,
     fromBlock,
     [],
   ]);
   const currentBaseFee = weiToString(
     feeHistory?.baseFeePerGas[feeHistory?.baseFeePerGas.length - 1]
   );
-
   const baseFees: number[] = [];
   const order = [];
   for (let i = 0; i < feeHistory.baseFeePerGas.length; i++) {
     baseFees.push(weiToGweiNumber(feeHistory.baseFeePerGas[i]));
     order.push(i);
   }
-
+  // calculate max, min and median
+  const calc = (baseFees: number[]) => {
+    const sortedBaseFees = baseFees.sort((a, b) => a - b);
+    const min = sortedBaseFees[0];
+    const max = sortedBaseFees[sortedBaseFees.length - 1];
+    const median = sortedBaseFees[Math.floor(sortedBaseFees.length / 2)];
+    return { max, median, min };
+  };
+  const createSubsets = (numbers: number[], n: number) => {
+    const subsets = [];
+    for (let i = 0; i < numbers.length; i = i + n) {
+      subsets.push(numbers.slice(i, i + n));
+    }
+    return subsets;
+  };
+  const getSubsetsData = (numbers: number[], n: number) => {
+    const subsets = createSubsets(numbers, n);
+    const subsetsInfo = subsets.map((subset) => calc(subset));
+    return subsetsInfo;
+  };
+  const getData = (numbers: number[], n: number) => {
+    const subsetsData = getSubsetsData(numbers, n);
+    const maxData = subsetsData.map((data) => data.max);
+    const minData = subsetsData.map((data) => data.min);
+    const medianData = subsetsData.map((data) => data.median);
+    const maxLR = linearRegression(maxData);
+    const minLR = linearRegression(minData);
+    const medianLR = linearRegression(medianData);
+    return {
+      max: maxData[maxData.length - 1],
+      maxLR,
+      median: medianData[medianData.length - 1],
+      medianLR,
+      min: minData[minData.length - 1],
+      minLR,
+    };
+  };
+  const baseFees5Blocks = baseFees.slice(blockCountHistory - 5 + 1);
+  const n5 = {
+    g1: getData(baseFees5Blocks, 1),
+    g5: getData(baseFees5Blocks, 5),
+  };
+  const baseFees25Blocks = baseFees.slice(blockCountHistory - 25 + 1);
+  const n25 = {
+    g1: getData(baseFees25Blocks, 1),
+    g5: getData(baseFees25Blocks, 5),
+  };
+  // blocks 50
+  const baseFees50Blocks = baseFees.slice(blockCountHistory - 50 + 1);
+  // groups 1, 5, 10
+  const n50 = {
+    g1: getData(baseFees50Blocks, 1),
+    g10: getData(baseFees50Blocks, 10),
+    g5: getData(baseFees50Blocks, 5),
+  };
+  // blocks 100
+  const baseFees100Blocks = baseFees.slice(1);
+  // groups 1, 5, 10
+  const n100 = {
+    g1: getData(baseFees100Blocks, 1),
+    g10: getData(baseFees100Blocks, 10),
+    g25: getData(baseFees100Blocks, 25),
+    g5: getData(baseFees100Blocks, 5),
+    g50: getData(baseFees100Blocks, 50),
+  };
+  // /////////////
+  const maxByMedian = n100.g25.max / n100.g25.median;
+  const minByMedian = n100.g25.min / n100.g25.median;
+  let trend = 0;
+  // surging
+  if (maxByMedian > 1.5) {
+    trend = 2;
+  } else if (maxByMedian > 1.275 && minByMedian > 0.725) {
+    trend = 1;
+  } else if (maxByMedian < 1.275 && minByMedian > 0.725) {
+    if (n50.g5.medianLR < -5) {
+      trend = -1;
+    } else {
+      trend = 0;
+    }
+  } else if (maxByMedian < 1.275 && minByMedian < 0.725) {
+    trend = -1;
+  } else {
+    // if none is on the threshold
+    if (weiToGweiNumber(currentBaseFee) > n100.g25.median) {
+      trend = 1;
+    } else {
+      trend = -1;
+    }
+  }
   baseFees[baseFees.length - 1] *= 9 / 8;
   for (let i = feeHistory.gasUsedRatio.length - 1; i >= 0; i--) {
     if (feeHistory.gasUsedRatio[i] > 0.9) {
       baseFees[i] = baseFees[i + 1];
     }
   }
-
   order.sort((a, b) => {
     const aa = baseFees[a];
     const bb = baseFees[b];
@@ -54,7 +141,6 @@ export const suggestMaxBaseFee = async (
     }
     return 0;
   });
-
   const result = [];
   let maxBaseFee = 0;
   for (let timeFactor = 15; timeFactor >= 0; timeFactor--) {
@@ -67,14 +153,18 @@ export const suggestMaxBaseFee = async (
     result[timeFactor] = bf;
   }
   const suggestedMaxBaseFee = Math.max(...result);
-
   return {
-    baseFeeTrend: calculateBaseFeeTrend(baseFees, currentBaseFee),
+    baseFeeTrend: trend,
     currentBaseFee,
     maxBaseFeeSuggestion: gweiToWei(suggestedMaxBaseFee),
+    trends: {
+      n100,
+      n25,
+      n5,
+      n50,
+    },
   };
 };
-
 export const suggestMaxPriorityFee = async (
   provider: JsonRpcProvider,
   fromBlock = 'latest'
@@ -138,11 +228,10 @@ export const suggestMaxPriorityFee = async (
     },
   };
 };
-
 export const suggestFees = async (
   provider: JsonRpcProvider
 ): Promise<Suggestions> => {
-  const { maxBaseFeeSuggestion, baseFeeTrend, currentBaseFee } =
+  const { maxBaseFeeSuggestion, trends, baseFeeTrend, currentBaseFee } =
     await suggestMaxBaseFee(provider);
   const { maxPriorityFeeSuggestions, confirmationTimeByPriorityFee } =
     await suggestMaxPriorityFee(provider);
@@ -152,5 +241,6 @@ export const suggestFees = async (
     currentBaseFee,
     maxBaseFeeSuggestion,
     maxPriorityFeeSuggestions,
+    trends,
   };
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,6 +139,14 @@ export const rewardsFilterOutliers = (
     .filter((_, index) => !outlierBlocks.includes(index))
     .map((reward) => weiToGweiNumber(reward[rewardIndex]));
 
+const calculateGroupInfo = (baseFees: number[]) => {
+  const sortedBaseFees = baseFees.sort((a, b) => a - b);
+  const min = sortedBaseFees[0];
+  const max = sortedBaseFees[sortedBaseFees.length - 1];
+  const median = sortedBaseFees[Math.floor(sortedBaseFees.length / 2)];
+  return { max, median, min };
+};
+
 const createSubsets = (numbers: number[], n: number) => {
   const subsets = [];
   for (let i = 0; i < numbers.length; i = i + n) {
@@ -147,32 +155,22 @@ const createSubsets = (numbers: number[], n: number) => {
   return subsets;
 };
 
-const calculateSubsetInfo = (baseFees: number[]) => {
-  const sortedBaseFees = baseFees.sort((a, b) => a - b);
-  const min = sortedBaseFees[0];
-  const max = sortedBaseFees[sortedBaseFees.length - 1];
-  const median = sortedBaseFees[Math.floor(sortedBaseFees.length / 2)];
-  return { max, median, min };
-};
-
-const getSubsetsData = (numbers: number[], n: number) => {
+export const getData = (numbers: number[], n: number) => {
   const subsets = createSubsets(numbers, n);
-  const subsetsInfo = subsets.map((subset) => calculateSubsetInfo(subset));
-  return subsetsInfo;
-};
-
-const getData = (numbers: number[], n: number) => {
-  const subsetsData = getSubsetsData(numbers, n);
-  const maxData = subsetsData.map((data) => data.max);
-  const minData = subsetsData.map((data) => data.min);
-  const medianData = subsetsData.map((data) => data.median);
+  const subsetsInfo = subsets.map((subset) => calculateGroupInfo(subset));
+  const {
+    max: lastMax,
+    min: lastMin,
+    median: lastMedian,
+  } = subsetsInfo[subsetsInfo.length - 1];
+  const medianData = subsetsInfo.map((data) => data.median);
   const medianSlope = linearRegression(medianData);
 
   return {
-    max: maxData[maxData.length - 1],
-    median: medianData[medianData.length - 1],
+    max: lastMax,
+    median: lastMedian,
     medianSlope,
-    min: minData[minData.length - 1],
+    min: lastMin,
   };
 };
 


### PR DESCRIPTION
Change the way we calculate trends

Following this logic:
- SURGING => block group max / block group median > 1.5
- RAISING => block group max / block group median > 1.25 && block group min / block group median > 0.75
- STABLE => block group max / block group median < 1.25 && block group min / block group median > 0.75
- FALLING => block group max / block group median < 1.25 && block group min / block group median < 0.75
- block group max / block group median > 1.25 && block group min / block group median < 0.75  => is going to be decided by the relation between the current base fee and the groups median base fee
        base fee  > median base fee => RAISING
        base fee <= median base fee => FALLING


