### PR TITLE
fix: hexidecimal number for eth_feehistory blockcount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
+import { utils } from 'ethers';
 import { ema } from 'moving-averages';
 import {
   BASE_FEE_ADDITIONAL_PADDING,
@@ -27,7 +28,7 @@ export const suggestMaxBaseFee = async (
   blockCountHistory = 100
 ): Promise<MaxFeeSuggestions> => {
   const feeHistory: FeeHistoryResponse = await provider.send('eth_feeHistory', [
-    blockCountHistory,
+    utils.hexStripZeros(utils.hexlify(blockCountHistory)),
     fromBlock,
     [],
   ]);
@@ -109,7 +110,7 @@ export const suggestMaxPriorityFee = async (
   fromBlock = 'latest'
 ): Promise<MaxPriorityFeeSuggestions> => {
   const feeHistory: FeeHistoryResponse = await provider.send('eth_feeHistory', [
-    10,
+    utils.hexStripZeros(utils.hexlify(10)),
     fromBlock,
     [10, 15, 30, 45],
   ]);


### PR DESCRIPTION
Hi!

First of all, thank you for creating this tool!
Its really great and has been working like a charm in projects that I've included it in.

However I had an issue running it against Quicknode's RPC servers.
You can test it with this simple `demo.ts`:

```ts
import { JsonRpcProvider } from '@ethersproject/providers';
import { suggestFees } from './src';

const main = async () => {
  try {
    const provider = new JsonRpcProvider("QUICKNODE_URL");
    const fee = await suggestFees(provider);
    // eslint-disable-next-line no-console
    console.log(fee);
  } catch (e) {
    // eslint-disable-next-line no-console
    console.error(e);
  }
};
main();
```

You will get this server error:
```json
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid type: integer `100`, expected a 0x-prefixed hex string with length between (0; 64]."},"id":42}
```

It looks like Infura and Alchemy both allow the use of an integer for the `blockCount` argument of `eth_feeHistory`.
But the doc actually specifies that it should be an hexadecimal number:
https://infura.io/docs/ethereum#operation/eth_feeHistory

This change fixes it by using ethers' hexadecimal `utils`.