### PR TITLE
fix: tsconfig noImplicitAny

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export const suggestMaxBaseFee = async (
     feeHistory?.baseFeePerGas[feeHistory?.baseFeePerGas.length - 1]
   );
   const baseFees: number[] = [];
-  const order = [];
+  const order: number[] = [];
   for (let i = 0; i < feeHistory.baseFeePerGas.length; i++) {
     baseFees.push(weiToGweiNumber(feeHistory.baseFeePerGas[i]));
     order.push(i);
@@ -59,7 +59,7 @@ export const suggestMaxBaseFee = async (
     }
     return 0;
   });
-  const result = [];
+  const result: number[] = [];
   let maxBaseFee = 0;
   for (let timeFactor = 15; timeFactor >= 0; timeFactor--) {
     let bf = suggestBaseFee(baseFees, order, timeFactor, 0.1, 0.3);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,7 +145,7 @@ const calculateGroupInfo = (baseFees: number[]) => {
 };
 
 const createSubsets = (numbers: number[], n: number) => {
-  const subsets = [];
+  const subsets: number[][] = [];
   for (let i = 0; i < numbers.length; i = i + n) {
     subsets.push(numbers.slice(i, i + n));
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false,                         /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
     // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */


### PR DESCRIPTION
While contributing to this repository I encountered a Typescript error when trying to use the library:

```bash
> yarn start

TSError: Unable to compile TypeScript:
src/index.ts:2:21 - error TS7016: Could not find a declaration file for module 'moving-averages'. 'fee-suggestions/node_modules/moving-averages/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/moving-averages` if it exists or add a new declaration (.d.ts) file containing `declare module 'moving-averages';`
```

I found out [here](https://amandeepkochhar.medium.com/typescript-error-could-not-find-a-declaration-file-for-module-xyz-dfbe6e45c2bd) that changing `noImplicitAny` to `false` could fix this issue, and it did.

Edit: This is a patch that works but setting `noImplicitAny` to `false` is not a good solution for the long term. Feel free to close this PR. I would suggest migrating from `moving-averages` to `moving-average` (without the "s") that supports Typescript: https://www.npmjs.com/package/moving-average