### PR TITLE
Rainbows Unauthorized Fees

### DIFF
--- a/RainbowsUnauthorizedFees
+++ b/RainbowsUnauthorizedFees
@@ -1,0 +1,13 @@
+Hello all,
+I have written previously about Rainbow falsely advertising a "free mint" on its app, and then subsequently charging an ethereum fee (in addition to the gas required to mint the NFT) without my knowledge or consent. When this matter was brought to the attention of Rainbow representatives, Rainbow inexplicably advised me to contact the Ethereum Foundation, to recoup the funds owed to me by Rainbow. 
+
+Rainbow has continued to attempt to evade accountability. Thus I am asking the broader community for advice and assistance on resolving this matter. I am also kindly requesting that Rainbow stops attempting to conceal and obscure this matter, including its deleting of these communications, until this matter is resolved.  
+
+The only way to communicate with Rainbow representatives has been on Github. In response, Rainbow has attempted to delete all evidence of these communications, and then communicating with me privately, while exerting no actual effort in resolving this matter, as demonstrated by Rainbow's latest response: 
+
+On Sun, May 12, 2024 at 9:59 AM MK <[notifications@github.com](mailto:notifications@github.com)> wrote:
+ **I know this is super frustrating, but please let's keep the conversation in this discussion [#1960](https://github.com/rainbow-me/rainbowkit/discussions/1960). Like i said the team is looking at this issue and we'll contact you back as soon as possible. The issue is unknown at the moment and our team is investigating this. Thanks for your patience 🙏**
+
+—
+
+**I am requesting the community's help in seeking a resolution to this matter, and ensuring Rainbow holds itself accountable for its actions. I am also kindly request that Rainbow stops attempting to conceal and obscure this matter, until it is resolved.** 


### PR DESCRIPTION
Hello all,
I have written previously about Rainbow falsely advertising a "free mint" on its app, and then subsequently charging an ethereum fee (in addition to the gas required to mint the NFT) without my knowledge or consent. When this matter was brought to the attention of Rainbow representatives, Rainbow inexplicably advised me to contact the Ethereum Foundation, to recoup the funds owed to me by Rainbow. 

Rainbow has continued to attempt to evade accountability. Thus I am asking the broader community for advice and assistance on resolving this matter. I am also kindly requesting that Rainbow stops attempting to conceal and obscure this matter, including its deleting of these communications, until this matter is resolved.  

The only way to communicate with Rainbow representatives has been on Github. In response, Rainbow has attempted to delete all evidence of these communications, and then communicating with me privately, while exerting no actual effort in resolving this matter, as demonstrated by Rainbow's latest response: 

On Sun, May 12, 2024 at 9:59 AM MK <[notifications@github.com](mailto:notifications@github.com)> wrote:
 **I know this is super frustrating, but please let's keep the conversation in this discussion [#1960](https://github.com/rainbow-me/rainbowkit/discussions/1960). Like i said the team is looking at this issue and we'll contact you back as soon as possible. The issue is unknown at the moment and our team is investigating this. Thanks for your patience 🙏**

—

**I am requesting the community's help in seeking a resolution to this matter, and ensuring Rainbow holds itself accountable for its actions. I am also kindly request that Rainbow stops attempting to conceal and obscure this matter, until it is resolved.**